### PR TITLE
Fix category filter for events

### DIFF
--- a/application.py
+++ b/application.py
@@ -84,18 +84,14 @@ def get_Events():
 
 
     responseDict = {}
+    categories = filters['category'] if filters.get('category') is not None else \
+        "school-holidays,public-holidays,politics,conferences,expos,concerts,festivals,performing-arts,sports,community"
 
-    if filters.get('category') == None:
-
-        for event in phq.events.search(category="school-holidays,public-holidays,politics,conferences,expos,concerts,festivals,performing-arts,sports,community", within=("{0}km@{1},{2}").format(distance, lat, lon)):
-            responseDict[event.title] = {"Description": event.description, "Category": event.category,
-                                         "EventID": event.id, "Location": event.location, "Start Date": event.start.strftime('%Y-%m-%d')}
-
-        return json.dumps(responseDict)
-
-    for event in phq.events.search(category="school-holidays,public-holidays,politics,conferences,expos,concerts,festivals,performing-arts,sports,community", within=("{0}km@{1},{2}").format(distance, lat, lon)):
+    for event in phq.events.search(category=categories,
+                                   within=("{0}km@{1},{2}").format(distance, lat, lon)):
         responseDict[event.title] = {"Description": event.description, "Category": event.category,
-                                     "EventID": event.id, "Location": event.location, "Start Date": event.start.strftime('%Y-%m-%d')}
+                                     "EventID": event.id, "Location": event.location,
+                                     "Start Date": event.start.strftime('%Y-%m-%d')}
 
     return json.dumps(responseDict)
 


### PR DESCRIPTION
## Summary
- use `filters['category']` in the events search query
- clean up duplication in `get_Events`

## Testing
- `python3 -m py_compile application.py`
- manual test with dummy PredictHQ and pyrebase objects

------
https://chatgpt.com/codex/tasks/task_e_684616aa17d883208a8f1d56d06fe594